### PR TITLE
feat(editor): allow to use EDITOR env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,7 +1994,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snix"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,6 +2019,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shell-words",
  "syntect",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ unicode-width = "0.2.0"
 flume = "0.11.1"
 futures = "0.3.31"
 reqwest = { version = "0.11", features = ["json", "stream", "rustls-tls"], default-features = false }
+shell-words = "1.1.1"

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -5,7 +5,6 @@ use crate::models::export::ExportFormat;
 use crate::ui::backup_restore;
 use crate::ui::colors::RosePine;
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use std::fmt::Debug;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -1449,7 +1449,14 @@ fn suspend_tui_for_editor(file_path: &std::path::Path) -> Result<(), Box<dyn std
     stdout().flush()?;
 
     // Try to launch editors in order of preference
-    let editors = ["nvim", "vim", "nano"];
+    let env_editor;
+    let editors = if let Ok(editor) = std::env::var("EDITOR") {
+        env_editor = editor;
+        vec![env_editor.as_str()]
+    } else {
+        vec!["nvim", "vim", "nano"]
+    };
+
     let mut editor_launched = false;
 
     for editor in &editors {

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -1452,14 +1452,19 @@ fn suspend_tui_for_editor(file_path: &std::path::Path) -> Result<(), Box<dyn std
     let (env_bin, env_args): (Option<String>, Vec<String>) = match std::env::var("EDITOR") {
         Err(_) => (None, vec![]),
         Ok(ref val) if val.trim().is_empty() => {
-            return Err(format!("$EDITOR is set but empty: {:?}", val).into());
+            eprintln!("Warning: $EDITOR is set but empty, falling back to defaults");
+            (None, vec![])
         }
-        Ok(ref val) => {
-            let mut parts = shell_words::split(val)
-                .map_err(|e| format!("Failed to parse $EDITOR {:?}: {}", val, e))?;
-            let bin = parts.remove(0);
-            (Some(bin), parts)
-        }
+        Ok(ref val) => match shell_words::split(val) {
+            Ok(parts) if !parts.is_empty() => (Some(parts[0].clone()), parts[1..].to_vec()),
+            _ => {
+                eprintln!(
+                    "Warning: could not parse $EDITOR {:?}, falling back to defaults",
+                    val
+                );
+                (None, vec![])
+            }
+        },
     };
 
     // Build the candidate list. $EDITOR goes first (when set)

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -5,6 +5,7 @@ use crate::models::export::ExportFormat;
 use crate::ui::backup_restore;
 use crate::ui::colors::RosePine;
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::fmt::Debug;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -1450,18 +1451,29 @@ fn suspend_tui_for_editor(file_path: &std::path::Path) -> Result<(), Box<dyn std
 
     // Try to launch editors in order of preference
     let env_editor;
-    let editors = if let Ok(editor) = std::env::var("EDITOR") {
+    let mut args: Vec<&str> = vec![];
+    let editors: Vec<&str> = if let Ok(editor) = std::env::var("EDITOR") {
         env_editor = editor;
-        vec![env_editor.as_str()]
+        let mut parts = env_editor.split_whitespace();
+        let bin = match parts.next() {
+            Some(b) => b,
+            None => return Err(format!("$EDITOR is set but empty: {:?}", env_editor).into()),
+        };
+        args = parts.collect();
+        vec![bin]
     } else {
         vec!["nvim", "vim", "nano"]
     };
 
     let mut editor_launched = false;
-
     for editor in &editors {
-        if let Ok(mut child) = Command::new(editor).arg(file_path).spawn() {
-            if let Ok(_) = child.wait() {
+        let mut cmd = Command::new(editor);
+        for arg in &args {
+            cmd.arg(arg);
+        }
+        cmd.arg(file_path);
+        if let Ok(mut child) = cmd.spawn() {
+            if child.wait().is_ok() {
                 editor_launched = true;
                 break;
             }
@@ -1469,7 +1481,12 @@ fn suspend_tui_for_editor(file_path: &std::path::Path) -> Result<(), Box<dyn std
     }
 
     if !editor_launched {
-        println!("Could not launch any editor (nvim, vim, nano)");
+        let tried = if args.is_empty() && editors != vec!["nvim", "vim", "nano"] {
+            editors.join(", ")
+        } else {
+            "nvim, vim, nano".to_string()
+        };
+        println!("Could not launch any editor ({tried})");
         println!("Press Enter to continue...");
         let mut buffer = String::new();
         std::io::stdin().read_line(&mut buffer)?;

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -1448,28 +1448,37 @@ fn suspend_tui_for_editor(file_path: &std::path::Path) -> Result<(), Box<dyn std
     print!("\x1B[?25h"); // Show cursor
     stdout().flush()?;
 
-    // Try to launch editors in order of preference
-    let env_editor;
-    let mut args: Vec<&str> = vec![];
-    let editors: Vec<&str> = if let Ok(editor) = std::env::var("EDITOR") {
-        env_editor = editor;
-        let mut parts = env_editor.split_whitespace();
-        let bin = match parts.next() {
-            Some(b) => b,
-            None => return Err(format!("$EDITOR is set but empty: {:?}", env_editor).into()),
-        };
-        args = parts.collect();
-        vec![bin]
-    } else {
-        vec!["nvim", "vim", "nano"]
+    // Parse $EDITOR with shell-words
+    let (env_bin, env_args): (Option<String>, Vec<String>) = match std::env::var("EDITOR") {
+        Err(_) => (None, vec![]),
+        Ok(ref val) if val.trim().is_empty() => {
+            return Err(format!("$EDITOR is set but empty: {:?}", val).into());
+        }
+        Ok(ref val) => {
+            let mut parts = shell_words::split(val)
+                .map_err(|e| format!("Failed to parse $EDITOR {:?}: {}", val, e))?;
+            let bin = parts.remove(0);
+            (Some(bin), parts)
+        }
     };
 
+    // Build the candidate list. $EDITOR goes first (when set)
+    let defaults = ["nvim", "vim", "nano"];
     let mut editor_launched = false;
-    for editor in &editors {
-        let mut cmd = Command::new(editor);
-        for arg in &args {
-            cmd.arg(arg);
+    let candidates: Vec<(&str, &[String])> = {
+        let mut v = vec![];
+        if let Some(ref bin) = env_bin {
+            v.push((bin.as_str(), env_args.as_slice()));
         }
+        for d in &defaults {
+            v.push((d, &[]));
+        }
+        v
+    };
+
+    for (editor, extra_args) in &candidates {
+        let mut cmd = Command::new(editor);
+        cmd.args(*extra_args);
         cmd.arg(file_path);
         if let Ok(mut child) = cmd.spawn() {
             if child.wait().is_ok() {
@@ -1480,12 +1489,8 @@ fn suspend_tui_for_editor(file_path: &std::path::Path) -> Result<(), Box<dyn std
     }
 
     if !editor_launched {
-        let tried = if args.is_empty() && editors != vec!["nvim", "vim", "nano"] {
-            editors.join(", ")
-        } else {
-            "nvim, vim, nano".to_string()
-        };
-        println!("Could not launch any editor ({tried})");
+        let tried: Vec<&str> = candidates.iter().map(|(bin, _)| *bin).collect();
+        println!("Could not launch any editor ({})", tried.join(", "));
         println!("Press Enter to continue...");
         let mut buffer = String::new();
         std::io::stdin().read_line(&mut buffer)?;


### PR DESCRIPTION
This is a pull request to make use of the EDITOR env variable if it's set.
Let me know if you want me to change something @parazeeknova 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Respect the EDITOR environment variable (including editor commands with arguments) and attempt to launch the configured editor, falling back to default editors if not set.
* **Bug Fixes / UX**
  * Treat an explicitly empty EDITOR as an error and show a clearer failure message that lists which editors were attempted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->